### PR TITLE
Update registration docs with info about the new DataFederations schema

### DIFF
--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -106,6 +106,25 @@ This is an example registration for a cache server that serves all public data _
     DN: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=my-combo-cache.example.net
 ```
 
+
+#### Non-standard ports
+
+By default, an unauthenticated cache serves public data on port 8000,
+and an authenticated cache serves protected data on port 8443.
+If you change the ports for your cache instances, you must specify the new endpoints under the service, as follows:
+
+```yaml
+  MY_COMBO_OSDF_CACHE2:
+    FQDN: my-combo-cache2.example.net
+    Services:
+      XRootD cache server:
+        Description: OSDF cache server
+        Details:
+          endpoint_override: my-combo-cache2.example.net:8080
+          auth_endpoint_override: my-combo-cache2.example.net:8444
+```
+
+
 ### Finalizing registration
 
 Once initial registration is complete, you may start the installation process.

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -263,9 +263,9 @@ Managing OSDF services
 -------------------------------------------
 
 These services must be managed by `systemctl` and may start additional services as dependencies.
-As a reminder, here are common service commands (all run as `root`) for EL7:
+As a reminder, here are common service commands (all run as `root`):
 
-| To...                                   | On EL7, run the command...         |
+| To...                                   | Run the command...                 |
 | :-------------------------------------- | :--------------------------------- |
 | Start a service                         | `systemctl start <SERVICE-NAME>`   |
 | Stop a service                          | `systemctl stop <SERVICE-NAME>`    |

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -242,7 +242,7 @@ For example:
 You can use the special value `ANY` to indicate that the origin will serve data from any VO that puts data on it.
 
 In addition to the origin allowing a VOs via the `AllowedVOs` list,
-that VO must also allow the origin in its `DataFederations/StashCache/AllowedOrigins` list.
+that VO must also allow the origin in one of its `AllowedOrigins` lists in `DataFederation/StashCache/Namespaces`.
 See the page on [getting your VO's data into OSDF](vo-data.md).
 
 Specifying the DN of your origin is not required but it is useful for testing.

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -37,7 +37,8 @@ Before starting the installation process, consider the following points:
   The [host certificate documentation](../../security/host-certs.md) provides more information on setting up host
   certificates.
 * __Network ports:__ The origin service requires the following ports open:
-  * Inbound TCP port 1094 for file access via the XRootD protocol
+  * Inbound TCP port 1094 for unauthenticated file access via the XRoot or HTTP protocols (unauthenticated origin only)
+  * Inbound TCP port 1095 for authenticated file access via the XRoot or HTTPS protocols (authenticated origin only)
   * Outbound TCP port 1213 to `redirector.osgstorage.org` for connecting to the data federation
   * Outbound UDP port 9930 for reporting to `xrd-report.osgstorage.org` and `xrd-mon.osgstorage.org` for monitoring.
 * __Hardware requirements:__ We recommend that an origin has at least 1Gbps connectivity and 8GB of RAM.
@@ -138,7 +139,7 @@ The origin service consists of the following SystemD units that you must directl
 These services must be managed with `systemctl` and may start additional services as dependencies.
 As a reminder, here are common service commands (all run as `root`):
 
-| To...                                   | On EL7, run the command...         |
+| To...                                   | Run the command...                 |
 | :-------------------------------------- | :--------------------------------- |
 | Start a service                         | `systemctl start <SERVICE-NAME>`   |
 | Stop a service                          | `systemctl stop <SERVICE-NAME>`    |

--- a/docs/data/stashcache/vo-data.md
+++ b/docs/data/stashcache/vo-data.md
@@ -160,16 +160,16 @@ A SciTokens authorization has multiple parameters, which are described below:
   construct the full path to the file that the token is allowed to access.
   For example, if `Base Path` is set to `/astro/PROTECTED` then a token with the scope `read:/matyas`
   will have the permission to read from the directory tree under `/astro/PROTECTED/matyas`.
-  
+
   The correct value for `Base Path` depends on how the issuer is set up, but we recommend that you set
   `Base Path` to the namespace path, and configure the issuer to create scopes relative to the namespace path.
 
-<!--
-- `Restricted Path` (optional) is a hack for a specific VO and shouldn't be used by anyone else
--->
-
 - `Map Subject` (optional, False if not specified) should be set to True if the origin uses the XRootD-Multiuser plugin.
   It will cause the origin to use the token subject (`sub` field) to map to a Unix user in order to access files.
+
+- `Restricted Path` (optional) is a further restriction on paths the token is allowed to access.
+  Only tokens whose scopes start with the `Restricted Path` will be accepted.
+  Use this only if your issuer does not create relative scopes.
 
 
 ### AllowedCaches list

--- a/docs/data/stashcache/vo-data.md
+++ b/docs/data/stashcache/vo-data.md
@@ -122,7 +122,7 @@ The list will contain one or more of these:
 - `FQAN: <VOMS FQAN>` allows someone using a proxy with the specified VOMS FQAN
 - `DN: <DN>` allows someone using a proxy with that specific DN
 - `PUBLIC` allows anyone; this is used for public data
-- `SciTokens` allows someone using a scitoken with the given parameters, which will be described below
+- `SciTokens` allows someone using a SciToken with the given parameters, which are described [below](#scitokens)
 
 A complete declaration looks like:
 ```yaml
@@ -152,12 +152,12 @@ or by someone with a SciToken issued by `https://astro.org`.
 
 #### SciTokens
 
-A SciTokens authorization has multiple parameters, which are described below:
+A SciTokens authorization has multiple parameters:
 
 - `Issuer` (required) is the token issuer of the SciToken that the authorization accepts.
   
 - `Base Path` (required) is a path that will be prepended to the scopes of the token in order to
-  construct the full path to the file that the token is allowed to access.
+  construct the full path to the file(s) that the bearer of the token is allowed to access.
   For example, if `Base Path` is set to `/astro/PROTECTED` then a token with the scope `read:/matyas`
   will have the permission to read from the directory tree under `/astro/PROTECTED/matyas`.
 

--- a/docs/data/stashcache/vo-data.md
+++ b/docs/data/stashcache/vo-data.md
@@ -78,7 +78,7 @@ DataFederations:
           - ANY
         AllowedOrigins:
           - ASTRO_OSDF_ORIGIN
-          
+
       - Path: /astro/PROTECTED
         Authorizations:
           - FQAN: /Astro
@@ -127,15 +127,22 @@ The list will contain one or more of these:
 A complete declaration looks like:
 ```yaml
     Namespaces:
-      /astro/PUBLIC:
-        - PUBLIC
-      /astro/PROTECTED:
-        - FQAN: /Astro
-        - DN: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Matyas Selmeci
-        - SciTokens:
-            Issuer: https://astro.org
-            Base Path: /astro/PROTECTED
-            Map Subject: True
+      - Path: /astro/PUBLIC
+        Authorizations:
+          - PUBLIC
+        AllowedCaches: ...
+        AllowedOrigins: ...
+
+      - Path: /astro/PROTECTED
+        Authorizations:
+          - FQAN: /Astro
+          - DN: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Matyas Selmeci
+          - SciTokens:
+              Issuer: https://astro.org
+              Base Path: /astro/PROTECTED
+              Map Subject: True
+        AllowedCaches: ...
+        AllowedOrigins: ...
 ```
 
 This declares two namespaces: `/astro/PUBLIC` for public data, and `/astro/PROTECTED`

--- a/docs/data/stashcache/vo-data.md
+++ b/docs/data/stashcache/vo-data.md
@@ -71,12 +71,27 @@ For example, the full registration for the `Astro` VO may look something like th
 DataFederations:
   StashCache:
     Namespaces:
-      /astro/PUBLIC:
-        - PUBLIC
-    AllowedCaches:
-      - ANY
-    AllowedOrigins:
-      - CHTC_OSDF_ORIGIN
+      - Path: /astro/PUBLIC
+        Authorizations:
+          - PUBLIC
+        AllowedCaches:
+          - ANY
+        AllowedOrigins:
+          - ASTRO_OSDF_ORIGIN
+          
+      - Path: /astro/PROTECTED
+        Authorizations:
+          - FQAN: /Astro
+          - DN: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Matyas Selmeci
+          - SciTokens:
+              Issuer: https://astro.org
+              Base Path: /astro/PROTECTED
+        AllowedCaches:
+          - ASTRO_EAST_CACHE
+          - ASTRO_WEST_CACHE
+        AllowedOrigins:
+          - ASTRO_AUTH_OSDF_ORIGIN
+
 ```
 
 The sections are described below.
@@ -84,14 +99,30 @@ The sections are described below.
 
 ### Namespaces section
 
-In the namespaces section, you will declare one or more namespaces and, for each namespace,
-list who is allowed to access that namespace.
+In the namespaces section, you will declare one or more namespaces.
+A namespace is a directory tree in the data federation that is owned by a VO/collaboration.
 
+Each namespace requires:
+- a `Path` that is the path to the directory tree, e.g. `/astro/PUBLIC`
+- an `Authorizations` list which describes how users are authorized to access data within the namespace
+- an `AllowedCaches` list of the OSDF caches that are allowed to cache the data within the namespace
+- an `AllowedOrigins` list of the OSDF origins that are allowed to serve the data within the namespace
+
+In addition, a namespace may have the following optional attributes:
+- a `Writeback` endpoint that is an HTTPS URL like `https://stash-xrd.osgconnect.net:1094`
+  that can be used for jobs to write data to the origin
+- a `DirList` endpoint that is an HTTPS URL like `https://origin-auth2001.chtc.wisc.edu:1095`
+  that can be used for getting a directory listing of that namespace
+
+### Authorizations list
+
+The Authorizations list of each namespace describes how a user can get authorized in order to access the data within the namespace.
 The list will contain one or more of these:
 
-- `FQAN:<VOMS FQAN>` allows someone using a proxy with the specified VOMS FQAN
-- `DN:<DN>` allows someone using a proxy with that specific DN
+- `FQAN: <VOMS FQAN>` allows someone using a proxy with the specified VOMS FQAN
+- `DN: <DN>` allows someone using a proxy with that specific DN
 - `PUBLIC` allows anyone; this is used for public data
+- `SciTokens` allows someone using a scitoken with the given parameters, which will be described below
 
 A complete declaration looks like:
 ```yaml
@@ -99,12 +130,39 @@ A complete declaration looks like:
       /astro/PUBLIC:
         - PUBLIC
       /astro/PROTECTED:
-        - FQAN:/Astro
-        - DN:/DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Matyas Selmeci
+        - FQAN: /Astro
+        - DN: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=People/CN=Matyas Selmeci
+        - SciTokens:
+            Issuer: https://astro.org
+            Base Path: /astro/PROTECTED
+            Map Subject: True
 ```
 
 This declares two namespaces: `/astro/PUBLIC` for public data, and `/astro/PROTECTED`
-which can only be read by someone with the `/Astro` FQAN or by Matyas Selmeci.
+which can only be read by someone with the `/Astro` FQAN, by Matyas Selmeci,
+or by someone with a SciToken issued by `https://astro.org`.
+
+
+#### SciTokens
+
+A SciTokens authorization has multiple parameters, which are described below:
+
+- `Issuer` (required) is the token issuer of the SciToken that the authorization accepts.
+  
+- `Base Path` (required) is a path that will be prepended to the scopes of the token in order to
+  construct the full path to the file that the token is allowed to access.
+  For example, if `Base Path` is set to `/astro/PROTECTED` then a token with the scope `read:/matyas`
+  will have the permission to read from the directory tree under `/astro/PROTECTED/matyas`.
+  
+  The correct value for `Base Path` depends on how the issuer is set up, but we recommend that you set
+  `Base Path` to the namespace path, and configure the issuer to create scopes relative to the namespace path.
+
+<!--
+- `Restricted Path` (optional) is a hack for a specific VO and shouldn't be used by anyone else
+-->
+
+- `Map Subject` (optional, False if not specified) should be set to True if the origin uses the XRootD-Multiuser plugin.
+  It will cause the origin to use the token subject (`sub` field) to map to a Unix user in order to access files.
 
 
 ### AllowedCaches list
@@ -148,4 +206,3 @@ The following requirements must be met for the resource:
 
 - It must have an "XRootD origin server" service
 - It must have an AllowedVOs list that includes either your VO or "ANY"
-


### PR DESCRIPTION
(SOFTWARE-5257)

This updates the registration docs with instructions for the new schema in https://github.com/opensciencegrid/topology/pull/2558

Haven't updated the container cache doc yet; needs #5 merged first.

Do not merge until the above topology PR is merged and deployed in production.