### PR TITLE
Add backfill container runtime requirement

### DIFF
--- a/docs/resource-sharing/os-backfill-containers.md
+++ b/docs/resource-sharing/os-backfill-containers.md
@@ -23,6 +23,7 @@ Before Starting
 
 In order to configure the container, you will need:
 
+1. A system that can run containers, such as Docker or Kubernetes
 1. A [registered administrative contact](https://osg-htc.org/technology/policy/comanage-instructions-user/)
 1. A [registered resource](../common/registration.md) in OSG Topology;
    resource registration allows OSG to do proper usage accounting and maintain contacts in case of security incidents


### PR DESCRIPTION
It was noted by a new site that there wasn't any indication that Docker was a requirement