### PR TITLE
Document for XCache 3.2.0+ auth/unauth origin support

### DIFF
--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -1,4 +1,5 @@
 title: Installing the OSDF Origin
+DateReviewed: 2022-12-16
 
 Installing the OSDF Origin
 ================================

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -158,7 +158,9 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull opensciencegrid/stash-origin:3.6-release
-ExecStart=/usr/bin/docker run --rm --name %n --publish 1094:1094 --publish 1095:1095 \
+ExecStart=/usr/bin/docker run --rm --name %n \
+  --publish 1094:1094 \
+  --publish 1095:1095 \
   --volume /srv/origin:/xcache/namespace \
   --volume /etc/ssl/host.crt:/etc/grid-security/hostcert.pem \
   --volume /etc/ssl/host.key:/etc/grid-security/hostkey.pem \

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -4,11 +4,6 @@ DateReviewed: 2020-06-22
 Running OSDF Origin in a Container
 ========================================
 
-!!! note
-    Currently, the origin container only supports distribution of public data.
-    If you would like to distribute private data requiring authentication,
-    see [the RPM installation guide](install-origin.md).
-
 The OSG operates the [Open Science Data Federation](overview.md) (OSDF), which
 provides organizations with a method to distribute their data in a scalable manner to thousands of jobs without needing
 to pre-stage data across sites or operate their own scalable infrastructure.
@@ -27,13 +22,18 @@ Before starting the installation process, consider the following requirements:
 
 1. **Docker:** For the purpose of this guide, the host must have a running docker service and you must have the ability
 to start containers (i.e., belong to the `docker` Unix group).
-1. **Network ports:** The origin listens for incoming HTTP(S) and XRootD connections on port 1094.
+1. **Network ports:** The origin listens for incoming HTTP(S) and XRootD connections on ports 1094 and/or 1095.
+   1094 is used for serving public (unauthenticated) data, and 1095 is used for serving authenticated data.
 1. **File Systems:** The origin needs a host partition to store user data.
 1. **Hardware requirements:** We recommend that an origin has at least 1Gbps connectivity and 8GB of RAM.
 1. **Host certificate:** Required for authentication.
   See our [host certificate documentation](../../security/host-certs.md) for instructions on how to request host certificates.
 1. **Registration:** Before deploying an origin, you must
    [register the service](install-origin.md#registering-the-origin) in the OSG Topology
+
+!!! note
+    This document describes features introduced in XCache 3.2.2, released on 2022-09-29.
+    You must use a version of the `opensciencegrid/stash-origin` image built after that date.
 
 Configuring the Origin
 ----------------------
@@ -50,6 +50,24 @@ and `<FQDN>` with the public DNS name that should be used to contact your origin
 XC_RESOURCENAME=YOUR_SITE_NAME
 ORIGIN_FQDN=<FQDN>
 ```
+
+In addition, define the following variables to specify which subpaths should be served as public (unauthenticated) data
+on port 1094, and which subpaths should be served as authenticated data on port 1095:
+
+```file
+XC_PUBLIC_ORIGIN_EXPORT=/<VO>/PUBLIC
+XC_AUTH_ORIGIN_EXPORT=/<VO>/PROTECTED
+```
+
+These paths are relative to the host partition being served -- see the [Populating Origin Data](#populating-origin-data)
+section below.
+
+If you only define `XC_AUTH_ORIGIN_EXPORT`, you will only serve data on port 1095.
+If you only define `XC_PUBLIC_ORIGIN_EXPORT`, you will only serve data on port 1094.
+If you do not define either, you will serve the entire host partition as public data on port 1094.
+
+!!! note
+    For backward compatibility, `XC_ORIGINEXPORT` is accepted as an alias for `XC_PUBLIC_ORIGIN_EXPORT`.
 
 ### Providing a host certificate
 
@@ -74,9 +92,17 @@ The OSDF namespace is shared by multiple VOs so you must
 [choose a namespace](vo-data.md#choosing-namespaces) for your own VO's data.
 When running an origin container, your chosen namespace must be reflected in your host partition.
 
-For example, if your host partition is `/srv/origin-public` and the name of your VO is `ASTRO`,
-you should store the Astro VO's public data in `/srv/origin-public/astro/`.
-Then, when starting container, you will mount `/srv/origin-public/` into `/xcache/namespace` in the container.
+For example, if your host partition is `/srv/origin` and the name of your VO is `ASTRO`,
+you should store the Astro VO's public data in `/srv/origin/astro/PUBLIC`,
+and protected data in `/srv/origin/astro/PROTECTED`.
+
+When starting the container, mount `/srv/origin/` into `/xcache/namespace` in the container,
+and set the environment variables `XC_PUBLIC_ORIGIN_EXPORT=/astro/PUBLIC` and `XC_AUTH_ORIGIN_EXPORT=/astro/PROTECTED`.
+
+You may omit `XC_AUTH_ORIGIN_EXPORT` if you are only serving public data,
+or omit `XC_PUBLIC_ORIGIN_EXPORT` if you are only serving protected data.
+If you omit both, the entire `/srv/origin` partition will be served as public data.
+
 
 Running the Origin
 ------------------
@@ -87,7 +113,7 @@ The following sections provide examples for starting origin containers from the 
 production-appropriate method using systemd.
 
 ```console
-user@host $ docker run --rm --publish 1094:1094 \
+user@host $ docker run --rm --publish 1094:1094 --publish 1095:1095 \
              --volume <HOST PARTITION>:/xcache/namespace \
              --volume <HOST CERT>:/etc/grid-security/hostcert.pem \
              --volume <HOST KEY>:/etc/grid-security/hostkey.pem \
@@ -98,8 +124,15 @@ user@host $ docker run --rm --publish 1094:1094 \
 Replacing `<HOST PARTITION>` with the host directory containing data that your origin should serve.
 See [this section](#populating-origin-data) for details.
 
-!!!warning
-    A container deployed this way will serve the entire contents of `<HOST PARTITION>`.
+!!! warning
+    Unless configured otherwise via the env file `/opt/origin/.env`,
+    a container deployed this way will serve the entire contents of `<HOST PARTITION>`.
+    See the [Configuring the Origin](#configuring-the-origin) section for information on how to
+    serve one subpath as public and another as protected.
+
+!!! note
+    You may omit `--publish 1094:1094` if you are only serving authenticated data,
+    or omit `--publish 1095:1095` if you are only serving public data.
 
 ### Running on origin container with systemd
 
@@ -107,7 +140,7 @@ An example systemd service file for the OSDF.
 This will require creating the environment file in the directory `/opt/origin/.env`.
 
 !!! note
-    This example systemd file assumes `<HOST PARTITION>` is `/srv/origin-public`,
+    This example systemd file assumes `<HOST PARTITION>` is `/srv/origin`,
     and the cert and key to use are in `/etc/ssl/host.crt` and `/etc/ssl/host.key`,
     respectively.
 
@@ -125,8 +158,8 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull opensciencegrid/stash-origin:3.6-release
-ExecStart=/usr/bin/docker run --rm --name %n --publish 1094:1094 \
-  --volume /srv/origin-public:/xcache/namespace \
+ExecStart=/usr/bin/docker run --rm --name %n --publish 1094:1094 --publish 1095:1095 \
+  --volume /srv/origin:/xcache/namespace \
   --volume /etc/ssl/host.crt:/etc/grid-security/hostcert.pem \
   --volume /etc/ssl/host.key:/etc/grid-security/hostkey.pem \
   --env-file /opt/origin/.env \
@@ -144,12 +177,22 @@ root@host $ systemctl start docker.stash-origin
 ```
 
 !!! warning
+    Unless configured otherwise via the env file `/opt/origin/.env`,
+    a container deployed this way will serve the entire contents of `/srv/origin`.
+    See the [Configuring the Origin](#configuring-the-origin) section for information on how to
+    serve one subpath as public and another as protected.
+
+!!! note
+    You may omit `--publish 1094:1094` if you are only serving authenticated data,
+    or omit `--publish 1095:1095` if you are only serving public data.
+
+!!! warning
     You must [register](install-origin.md#registering-the-origin) the origin before starting it up.
 
 
 
-Validating Origin
------------------
+Validating the Origin
+---------------------
 
 To validate the origin please follow the
 [validating origin instructions](install-origin.md#verifying-the-origin-server).

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -1,5 +1,5 @@
 title: Running OSDF Origin in a Container
-DateReviewed: 2020-06-22
+DateReviewed: 2022-12-16
 
 Running OSDF Origin in a Container
 ========================================


### PR DESCRIPTION
[SOFTWARE-3615: Document XCache 3.2.0 auth/unauth origin variables](https://opensciencegrid.atlassian.net/browse/SOFTWARE-3615)