### PR TITLE
Update cache/origin docs to refer to the new authfile service and timer

### DIFF
--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -204,7 +204,7 @@ When usage goes above the high water mark,
 the XRootD service will delete cached files until usage goes below the low water mark.
 
 
-### Enable remote debugging
+### Enable remote debugging (only if needed)
 
 XRootD provides remote debugging via a read-only file system named digFS.
 This feature is disabled by default, but you may enable it if you need help troubleshooting your server.

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -1,4 +1,5 @@
 title: Installing the OSDF Cache
+DateReviewed: 2023-03-03
 
 Installing the OSDF Cache
 =========================

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -8,6 +8,10 @@ This document describes how to install an Open Science Data Federation (OSDF) ca
 network to cache data frequently used on the OSG, reducing data transfer over the wide-area network and
 decreasing access latency.
 
+!!! note "Minimum version for this documentation"
+    This document describes features introduced in XCache 3.3.0, released on 2022-12-08.
+    When installing, ensure that your version of the `stash-cache` RPM is at least 3.3.0.
+
 !!! note
     The OSDF cache was previously named "Stash Cache" and some documentation and software may use the old name.
 
@@ -38,10 +42,6 @@ As with all OSG software installations, there are some one-time steps to prepare
 * Obtain root access to the host
 * Prepare [the required Yum repositories](../../common/yum.md)
 * Install [CA certificates](../../common/ca.md)
-
-!!! note "Minimum version for this documentation"
-    This document describes features introduced in XCache 3.3.0, released on 2022-12-08.
-    When installing, ensure that your version of the `stash-cache` RPM is at least 3.3.0.
 
 <!-- NOTE: Keep the "Registering the Cache" section below in sync with run-stashcache-container.md -->
 
@@ -212,10 +212,13 @@ When usage goes above the high water mark,
 the XRootD service will delete cached files until usage goes below the low water mark.
 
 
-### Enable remote debugging (only if needed)
+### Enable remote debugging
 
 XRootD provides remote debugging via a read-only file system named digFS.
 This feature is disabled by default, but you may enable it if you need help troubleshooting your server.
+
+!!! warning
+    Remote debugging should only be enabled for long as it is needed to troubleshoot your server.
 
 To enable remote debugging, edit `/etc/xrootd/digauth.cfg` and specify the authorizations for reading digFS.
 An example of authorizations:
@@ -258,28 +261,17 @@ Manually Setting the FQDN (optional)
 ------------------------------------
 The FQDN of the cache server that you registered in [Topology](#registering-the-cache) may be different than its internal hostname
 (as reported by `hostname -f`).
-For example, this may be the case if your cache is behind a load balancer such as LVS or MetalLB.
+For example, this may be the case if your cache is behind a load balancer such as LVS.
 In this case, you must manually tell the cache services which FQDN to use for topology lookups.
 
-If you are running a public cache instance:
-
-1.  Create the file `/etc/systemd/system/stash-authfile@stash-cache.service.d/override.conf`
-    with the following contents:
+1.  Create the file `/etc/systemd/system/stash-authfile@.service.d/override.conf`
+    (note the `@` in the directory name) with the following contents:
    
         :::ini
         [Service]
         Environment=CACHE_FQDN=<Topology-registered FQDN>
 
-
-If you are running an authenticated cache instance:
-
-1.  Create the file `/etc/systemd/system/stash-authfile@stash-cache-auth.service.d/override.conf`
-    with the following contents:
-   
-        :::ini
-        [Service]
-        Environment=CACHE_FQDN=<Topology-registered FQDN>
-
+1.  Run `systemctl daemon-reload` after modifying the file.
 
 Managing OSDF services
 -------------------------------------------
@@ -294,7 +286,7 @@ As a reminder, here are common service commands (all run as `root`):
 | Enable a service to start on boot       | `systemctl enable <SERVICE-NAME>`  |
 | Disable a service from starting on boot | `systemctl disable <SERVICE-NAME>` |
 
-### Public cache services (if running a public cache instance)
+### Public cache services
 
 | **Software** | **Service name** | **Notes** |
 |--------------|------------------|-----------|
@@ -305,7 +297,7 @@ As a reminder, here are common service commands (all run as `root`):
 | | `stash-authfile@stash-cache.timer` | Periodically run the above service (public cache instance) |
 
 
-### Authenticated cache services (if running an authenticated cache instance)
+### Authenticated cache services
 
 
 

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -20,11 +20,15 @@ Before starting the installation process, consider the following requirements:
   `xrootd`
 * __Host certificate:__ Required for authentication.
   See our [host certificate documentation](../../security/host-certs.md) for instructions on how to request and install host certificates.
-* __Network ports:__ The cache service requires the following ports open:
-    * Inbound TCP port 1094 for file access via the XRootD protocol
-    * Inbound TCP port 8000 for file access via HTTP and/or
-    * Inbound TCP port 8443 for authenticated file access via HTTPS
-    * Outbound UDP port 9930 for reporting to `xrd-report.osgstorage.org` and `xrd-mon.osgstorage.org` for monitoring
+* __Network ports:__ Your host may run a public cache instance (for serving public data only), an authenticated cache instance (for serving protected data), or both.
+    
+    * A public cache instance requires the following ports open:
+        * Inbound TCP port 1094 for file access via the XRootD protocol
+        * Inbound TCP port 8000 for file access via HTTP(S)
+        * Outbound UDP port 9930 for reporting to `xrd-report.osgstorage.org` and `xrd-mon.osgstorage.org` for monitoring
+    * An authenticated cache instance requires the following ports open:
+        * Inbound TCP port 8443 for authenticated file access via HTTPS
+        * Outbound UDP port 9930 for reporting to `xrd-report.osgstorage.org` and `xrd-mon.osgstorage.org` for monitoring
 * __Hardware requirements:__ We recommend that a cache has at least 10Gbps connectivity, 1TB of
  disk space for the cache directory, and 12GB of RAM.
 
@@ -110,8 +114,8 @@ This is an example registration for a cache server that serves all public data _
 
 #### Non-standard ports
 
-By default, an unauthenticated cache serves public data on port 8000,
-and an authenticated cache serves protected data on port 8443.
+By default, an unauthenticated cache instance serves public data on port 8000,
+and an authenticated cache instance serves protected data on port 8443.
 If you change the ports for your cache instances, you must specify the new endpoints under the service, as follows:
 
 ```yaml
@@ -253,7 +257,19 @@ The FQDN of the cache server that you registered in [Topology](#registering-the-
 For example, this may be the case if your cache is behind a load balancer such as LVS or MetalLB.
 In this case, you must manually tell the cache services which FQDN to use for topology lookups.
 
-1.  Create the file `/etc/systemd/system/stash-cache-authfile.service.d/override.conf`
+If you are running a public cache instance:
+
+1.  Create the file `/etc/systemd/system/stash-authfile@stash-cache.service.d/override.conf`
+    with the following contents:
+   
+        :::ini
+        [Service]
+        Environment=CACHE_FQDN=<Topology-registered FQDN>
+
+
+If you are running an authenticated cache instance:
+
+1.  Create the file `/etc/systemd/system/stash-authfile@stash-cache-auth.service.d/override.conf`
     with the following contents:
    
         :::ini

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -39,7 +39,7 @@ As with all OSG software installations, there are some one-time steps to prepare
 * Prepare [the required Yum repositories](../../common/yum.md)
 * Install [CA certificates](../../common/ca.md)
 
-!!! note
+!!! note "Minimum version for this documentation"
     This document describes features introduced in XCache 3.3.0, released on 2022-12-08.
     When installing, ensure that your version of the `stash-cache` RPM is at least 3.3.0.
 

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -38,6 +38,9 @@ As with all OSG software installations, there are some one-time steps to prepare
 * Prepare [the required Yum repositories](../../common/yum.md)
 * Install [CA certificates](../../common/ca.md)
 
+!!! note
+    This document describes features introduced in XCache 3.3.0, released on 2022-12-08.
+    When installing, ensure that your version of the `stash-cache` RPM is at least 3.3.0.
 
 <!-- NOTE: Keep the "Registering the Cache" section below in sync with run-stashcache-container.md -->
 

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -290,26 +290,28 @@ As a reminder, here are common service commands (all run as `root`):
 | Enable a service to start on boot       | `systemctl enable <SERVICE-NAME>`  |
 | Disable a service from starting on boot | `systemctl disable <SERVICE-NAME>` |
 
-### Public cache services
+### Public cache services (if running a public cache instance)
 
 | **Software** | **Service name** | **Notes** |
 |--------------|------------------|-----------|
 | XRootD | `xrootd@stash-cache.service` | The XRootD daemon, which performs the data transfers |
 | XCache | `xcache-reporter.timer` | Reports usage information to collector.opensciencegrid.org |
 | Fetch CRL |EL8: `fetch-crl.timer` <br> EL7: `fetch-crl-boot` and `fetch-crl-cron` | Required to authenticate monitoring services.  See [CA documentation](../../common/ca.md#managing-fetch-crl-services) for more info |
+| | `stash-authfile@stash-cache.service` | Generate authentication configuration files for XRootD (public cache instance) |
+| | `stash-authfile@stash-cache.timer` | Periodically run the above service (public cache instance) |
 
 
-### Authenticated cache services (optional)
+### Authenticated cache services (if running an authenticated cache instance)
 
-In addition to the public cache services, there are three systemd units specific to the authenticated cache.
+
 
 | **Software** | **Service name** | **Notes** |
 |--------------|------------------|-----------|
 | XRootD | `xrootd-renew-proxy.service` | Renew a proxy for authenticated downloads to the cache |
 |  | `xrootd@stash-cache-auth.service` | The xrootd daemon which performs authenticated data transfers |
 |  | `xrootd-renew-proxy.timer` | Trigger daily proxy renewal |
-|  | `stash-cache-authfile.service` | Generate the Authentication configuration file for XRootD |
-|  | `stash-cache-authfile.timer` | Periodically generate the Authentication configuration file for XRootD |
+|  | `stash-authfile@stash-cache-auth.service` | Generate the authentication configuration files for XRootD (authenticated cache instance) |
+|  | `stash-authfile@stash-cache-auth.timer` | Periodically run the above service (authenticated cache instance) |
 
 
 Validating the Cache

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -7,6 +7,10 @@ Installing the OSDF Origin
 This document describes how to install an Open Science Data Federation (OSDF) origin service.  This service allows an organization
 to export its data to the data federation.
 
+!!! note "Minimum version for this documentation"
+    This document describes features introduced in XCache 3.3.0, released on 2022-12-08.
+    When installing, ensure that your version of the `stash-origin` RPM is at least 3.3.0.
+
 !!! note
     The OSDF Origin was previously named "Stash Origin" and some documentation and software may use the old name.
 
@@ -45,11 +49,6 @@ As with all OSG software installations, there are some one-time steps to prepare
 * Obtain root access to the host
 * Prepare [the required Yum repositories](../../common/yum.md)
 * Install [CA certificates](../../common/ca.md)
-
-!!! note
-    This document describes features introduced in XCache 3.3.0, released on 2022-12-08.
-    When installing, ensure that your version of the `stash-origin` RPM is at least 3.3.0.
-
 
 Installing the Origin
 ---------------------
@@ -120,28 +119,18 @@ Manually Setting the FQDN (optional)
 ------------------------------------
 The FQDN of the origin server that you registered in [Topology](#registering-the-origin) may be different than its internal hostname
 (as reported by `hostname -f`).
-For example, this may be the case if your origin is behind a load balancer such as LVS or MetalLB.
+For example, this may be the case if your origin is behind a load balancer such as LVS.
 In this case, you must manually tell the origin services which FQDN to use for topology lookups.
 
 
-If you are running a public origin instance:
-
-1.  Create the file `/etc/systemd/system/stash-authfile@stash-origin.service.d/override.conf`
+1.  Create the file `/etc/systemd/system/stash-authfile@.service.d/override.conf`
     with the following contents:
    
         :::ini
         [Service]
         Environment=ORIGIN_FQDN=<Topology-registered FQDN>
 
-
-If you are running an authenticated origin instance:
-
-1.  Create the file `/etc/systemd/system/stash-authfile@stash-origin-auth.service.d/override.conf`
-    with the following contents:
-   
-        :::ini
-        [Service]
-        Environment=ORIGIN_FQDN=<Topology-registered FQDN>
+1.  Run `systemctl daemon-reload` after modifying the file.
 
 Managing the Origin Services
 ----------------------------
@@ -150,7 +139,13 @@ There can be multiple instances of `xrootd`, running on different ports.
 The instance that serves unauthenticated data will run on port 1094.
 The instance that serves authenticated data will run on port 1095.
 If your origin serves both authenticated and unauthenticated data, you will run both instances.
-Some of the service names are different if you have configured the [XRootD Multiuser plugin][multiuser].
+
+!!! note "Use of multiuser plugin"
+    Some of the service names are different if you have configured the [XRootD Multiuser plugin][multiuser]:
+    -   `xrootd-privileged` is used instead of `xrootd`
+    -   `cmsd-privileged` is used instead of `cmsd`
+
+    The privileged and non-privileged services are mutually exclusive.
 
 The origin services consist of the following SystemD units that you must directly manage:
 

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -47,8 +47,8 @@ As with all OSG software installations, there are some one-time steps to prepare
 * Install [CA certificates](../../common/ca.md)
 
 !!! note
-    This document describes features introduced in XCache 3.2.2, released on 2022-09-29.
-    When installing, ensure that your version of the `stash-origin` RPM is at least 3.2.2.
+    This document describes features introduced in XCache 3.3.0, released on 2022-12-08.
+    When installing, ensure that your version of the `stash-origin` RPM is at least 3.3.0.
 
 
 Installing the Origin

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -1,5 +1,5 @@
 title: Installing the OSDF Origin
-DateReviewed: 2022-12-16
+DateReviewed: 2023-03-03
 
 Installing the OSDF Origin
 ================================


### PR DESCRIPTION
[SOFTWARE-5473](https://opensciencegrid.atlassian.net/browse/SOFTWARE-5473). I also mentioned that you could run an auth instance, unauth instance, or both, and also that you need different services on the origin for multiuser.

[SOFTWARE-5473]: https://opensciencegrid.atlassian.net/browse/SOFTWARE-5473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ