### PR TITLE
Remove note about Compute Element

### DIFF
--- a/docs/compute-element/htcondor-ce-overview.md
+++ b/docs/compute-element/htcondor-ce-overview.md
@@ -28,9 +28,6 @@ Successful pilot jobs create and make available an environment for actual end-us
 within the pilot job container.
 Eventually pilot jobs remove themselves, typically after a period of inactivity.
 
-!!! note
-    The Compute Entrypoint was previously known as the "Compute Element".
-
 What is HTCondor-CE?
 --------------------
 


### PR DESCRIPTION
This is really a proposal more than a request. I’m wondering if we can let go of the “Compute Element” terminology once and for all now. It seems to me like it has been long enough, but I am happy to defer to others if it seems like there is still confusion around the CE term and what it means.