### PR TITLE
Update OSG 3.6 container references to use OSG 23 (SOFTWARE-5693)

### DIFF
--- a/docs/data/run-frontier-squid-container.md
+++ b/docs/data/run-frontier-squid-container.md
@@ -84,7 +84,7 @@ To run a Frontier Squid container with the defaults:
 user@host $ docker run --rm --name frontier-squid \
              -v <HOST CACHE PARTITION>:/var/cache/squid \
              -v <HOST LOG PARTITION>:/var/log/squid \
-             -p <HOST PORT>:3128 opensciencegrid/frontier-squid:3.6-release
+             -p <HOST PORT>:3128 opensciencegrid/frontier-squid:23-release
 ```
 
 You may pass configuration variables in `KEY=VALUE` format with either
@@ -112,8 +112,8 @@ TimeoutStartSec=0
 Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
-ExecStartPre=/usr/bin/docker pull opensciencegrid/frontier-squid:3.6-release
-ExecStart=/usr/bin/docker run --rm --name %n --publish 3128:3128 -v /tmp/squid:/var/cache/squid -v /tmp/log:/var/log/squid --env-file /opt/xcache/.env opensciencegrid/frontier-squid:3.6-release
+ExecStartPre=/usr/bin/docker pull opensciencegrid/frontier-squid:23-release
+ExecStart=/usr/bin/docker run --rm --name %n --publish 3128:3128 -v /tmp/squid:/var/cache/squid -v /tmp/log:/var/log/squid --env-file /opt/xcache/.env opensciencegrid/frontier-squid:23-release
 
 
 [Install]

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -118,7 +118,7 @@ user@host $ docker run --rm --publish 1094:1094 --publish 1095:1095 \
              --volume <HOST CERT>:/etc/grid-security/hostcert.pem \
              --volume <HOST KEY>:/etc/grid-security/hostkey.pem \
              --env-file=/opt/origin/.env \
-             opensciencegrid/stash-origin:3.6-release
+             opensciencegrid/stash-origin:23-release
 ```
 
 Replacing `<HOST PARTITION>` with the host directory containing data that your origin should serve.
@@ -157,7 +157,7 @@ TimeoutStartSec=0
 Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
-ExecStartPre=/usr/bin/docker pull opensciencegrid/stash-origin:3.6-release
+ExecStartPre=/usr/bin/docker pull opensciencegrid/stash-origin:23-release
 ExecStart=/usr/bin/docker run --rm --name %n \
   --publish 1094:1094 \
   --publish 1095:1095 \
@@ -165,7 +165,7 @@ ExecStart=/usr/bin/docker run --rm --name %n \
   --volume /etc/ssl/host.crt:/etc/grid-security/hostcert.pem \
   --volume /etc/ssl/host.key:/etc/grid-security/hostkey.pem \
   --env-file /opt/origin/.env \
-  opensciencegrid/stash-origin:3.6-release
+  opensciencegrid/stash-origin:23-release
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -191,7 +191,7 @@ user@host $ docker run --rm \
              ...
              --volume <DATA PARTITION N>:/xcache/dataN
              --env-file=/opt/xcache/.env \
-             opensciencegrid/stash-cache:3.6-release
+             opensciencegrid/stash-cache:23-release
 ```
 
 !!! warning
@@ -210,7 +210,7 @@ user@host $ docker run --rm \
              --volume <HOST CERT>:/etc/grid-security/hostcert.pem \
              --volume <HOST KEY>:/etc/grid-security/hostkey.pem \
              --env-file=/opt/xcache/.env \
-             opensciencegrid/stash-cache:3.6-release
+             opensciencegrid/stash-cache:23-release
 ```
 
 ### Running a cache on container with systemd
@@ -236,7 +236,7 @@ TimeoutStartSec=0
 Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
-ExecStartPre=/usr/bin/docker pull opensciencegrid/stash-cache:3.6-release
+ExecStartPre=/usr/bin/docker pull opensciencegrid/stash-cache:23-release
 ExecStart=/usr/bin/docker run --rm --name %n \
   --publish 8000:8000 \
   --publish 8443:8443 \
@@ -244,7 +244,7 @@ ExecStart=/usr/bin/docker run --rm --name %n \
   --volume /etc/ssl/host.crt:/etc/grid-security/hostcert.pem \
   --volume /etc/ssl/host.key:/etc/grid-security/hostkey.pem \
   --env-file /opt/xcache/.env \
-  opensciencegrid/stash-cache:3.6-release
+  opensciencegrid/stash-cache:23-release
 
 [Install]
 WantedBy=multi-user.target
@@ -274,7 +274,7 @@ user@host $ docker run --rm  \
              --volume <HOST CERT>:/etc/grid-security/hostcert.pem \
              --volume <HOST KEY>:/etc/grid-security/hostkey.pem \
              --env-file=/opt/xcache/.env \
-             opensciencegrid/stash-cache:3.6-release
+             opensciencegrid/stash-cache:23-release
 ```
 
 ### Memory optimization ###

--- a/docs/resource-sharing/os-backfill-containers.md
+++ b/docs/resource-sharing/os-backfill-containers.md
@@ -84,7 +84,7 @@ docker run -it --rm --user osg  \
        -e CVMFSEXEC_REPOS="                     \
             oasis.opensciencegrid.org           \
             singularity.opensciencegrid.org"    \
-       opensciencegrid/osgvo-docker-pilot:3.6-release
+       opensciencegrid/osgvo-docker-pilot:23-release
 ```
 
 Replace `/path/to/token` with the location you saved the token obtained from the OSPool Token Registry.
@@ -208,7 +208,7 @@ docker run -it --rm --user osg      \
         -e GLIDEIN_ResourceName="..."   \
         -e GLIDEIN_Start_Extra="True"   \
         -e OSG_SQUID_LOCATION="..."     \
-        opensciencegrid/osgvo-docker-pilot:3.6-release
+        opensciencegrid/osgvo-docker-pilot:23-release
 ```
 
 Fill in the values for `/path/to/token`, `/worker-temp-dir`, `GLIDEIN_Site`, `GLIDEIN_ResourceName`, and `OSG_SQUID_LOCATION` [as above](#running-the-container-with-docker).

--- a/docs/resource-sharing/user-containers.md
+++ b/docs/resource-sharing/user-containers.md
@@ -51,7 +51,7 @@ singularity run --contain \
                 --bind /cvmfs \
                 --bind /dev/fuse \
                 --scratch /pilot \
-                docker://opensciencegrid/osgvo-docker-pilot:3.6-release
+                docker://opensciencegrid/osgvo-docker-pilot:23-release
 ```
 
 The above example rebuilds the Docker container on each host.
@@ -59,7 +59,7 @@ If you plan to run large numbers of these jobs, you can download the Docker cont
 Singularity image:
 
 ```
-$ singularity build osgvo-pilot.sif docker://opensciencegrid/osgvo-docker-pilot:3.6-release
+$ singularity build osgvo-pilot.sif docker://opensciencegrid/osgvo-docker-pilot:23-release
 ```
 
 In this case, the `singularity run` command should be changed to:

--- a/docs/security/tokens/using-tokens.md
+++ b/docs/security/tokens/using-tokens.md
@@ -48,7 +48,7 @@ which is useful for looking inside tokens.
 1. Start an agent container in the background and name it `my-agent` to easily run subsequent commands against it:
 
         :::console
-        docker run -d --name my-agent opensciencegrid/oidc-agent:3.6-release
+        docker run -d --name my-agent opensciencegrid/oidc-agent:23-release
 
 1. Generate a local client profile and follow the prompts:
 


### PR DESCRIPTION
At this point, I'm very comfortable pushing folks to OSG 23 images over OSG 3.6