### PR TITLE
Add info on ENABLE_SHA1 flag on cache and origin containers (SOFTWARE-5809)

### DIFF
--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -85,6 +85,18 @@ and the key to `/etc/grid-security/hostkey.pem`.
     [on the Certbot site](https://certbot.eff.org/docs/using.html#renewing-certificates).
 
 
+!!! note
+    A small number of CAs in the IGTF and OSG CA cert distributions were signed with the SHA1 algorithm,
+    which is not accepted by default starting with Enterprise Linux 9.
+    If you are running an origin image based on OSG 23 or newer, and your situation includes any of the following:
+    
+    -   Your origin's host certificate was signed by a SHA1-signed-CA
+    -   You are expecting connections from clients or caches that authenticate themselves
+        with a cert from a SHA1-signed-CA
+    
+    then you must add `ENABLE_SHA1=yes` to the environment variable file.
+
+
 Populating Origin Data
 ----------------------
 

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -142,6 +142,17 @@ and the key to `/etc/grid-security/hostkey.pem`.
     For example, if you are using Certbot for Let's Encrypt, you should write a "deploy hook" as documented
     [on the Certbot site](https://certbot.eff.org/docs/using.html#renewing-certificates).
 
+!!! note
+    A small number of CAs in the IGTF and OSG CA cert distributions were signed with the SHA1 algorithm,
+    which is not accepted by default starting with Enterprise Linux 9.
+    If you are running a cache image based on OSG 23 or newer, and your situation includes any of the following:
+    
+    -   Your cache's host certificate was signed by a SHA1-signed-CA
+    -   You are expecting connections from clients that authenticate themselves with a cert from a SHA1-signed-CA
+    -   Your cache serves data from an origin whose host certificate was signed by a SHA1-signed-CA
+    
+    then you must add `ENABLE_SHA1=yes` to the environment variable file.
+
 
 ### Optional configuration ###
 


### PR DESCRIPTION
These are the two places I could find to add the info on the ENABLE_SHA1 flag. The documentation for running a hosted CE is elsewhere; Frontier-Squids I assume don't use grid certs for auth; we don't have an XRootD-Standalone image; ENABLE_SHA1 doesn't work on the EP containers (because they don't run as root and you need root to run update-crypto-policy).

There are numerous non-containerized services where a blurb mentioning EL9 and update-crypto-policy might be useful, though, but that should be a separate PR (and perhaps ticket).