### PR TITLE
Update XRootD Standalone and other XRootD docs to OSG 23 (SOFTWARE-5820)

### DIFF
--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -34,11 +34,6 @@ As with all OSG software installations, there are some one-time (per host) steps
 Installing XRootD
 -----------------
 
-!!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
-    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
-    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
-    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
-
 To install an XRootD Standalone server, run the following command:
 
 ```console
@@ -103,11 +98,6 @@ If you do not need any of the following special configurations, skip to
 
 #### Enabling multi-user support
 
-!!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
-    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
-    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
-    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
-
 The `xrootd-multiuser` plugin allows XRootD to write files on the storage system as the
 [authenticated](xrootd-authorization.md) user instead of the `xrootd` user.
 If your XRootD service only allows read-only access, you should skip installation of this plugin.
@@ -117,6 +107,8 @@ To set up XRootD in multi-user mode, install the `xrootd-multiuser` package:
 ``` console
 root@xrootd-standalone # yum install xrootd-multiuser
 ```
+
+If you are using XRootD-Multiuser with a VOMS FQAN, you need XRootD 5.5.0 or greater.
 
 #### Throttling IO requests
 

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -143,7 +143,7 @@ see the [upstream documentation](https://github.com/xrootd/xrootd/tree/master/sr
 For CMS sites, there is a package available to integrate rule-based name lookup using a `storage.xml` file.
 If you are not setting up a service for CMS, skip this section.
 
-To install an `xrootd-cmstfc` on OSG 3.6, run the following command:
+To install an `xrootd-cmstfc`, run the following command:
 
 ``` console
 root@xrootd-standalone # yum install --enablerepo=osg-contrib xrootd-cmstfc
@@ -172,7 +172,7 @@ The specific services are:
 
 | Software          | Service Name                          | Notes                                                                                                       |
 |:------------------|:--------------------------------------|:------------------------------------------------------------------------------------------------------------|
-| Fetch CRL         | EL8: `fetch-crl.timer` <br> EL7: `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](../../common/ca.md#managing-fetch-crl-services) for more info                        |
+| Fetch CRL         | EL8,EL9: `fetch-crl.timer` <br> EL7: `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](../../common/ca.md#managing-fetch-crl-services) for more info                        |
 | XRootD            | `xrootd@standalone`                   | Primary xrootd service if _not_ running in [multi-user mode](#enabling-multi-user-support)                |
 | XRootD Multi-user | `xrootd-privileged@standalone`        | Primary xrootd service to start _instead of_ `xrootd@standalone` if running in [multi-user mode](#enabling-multi-user-support) |
 
@@ -282,5 +282,4 @@ root@host # systemctl start xrootd@standalone
 
 | Service/Process          | Log File                                | Description                                 |
 |:-------------------------|:----------------------------------------|:--------------------------------------------|
-| `xrootd`                 | `/var/log/xrootd/server/xrootd.log`     | XRootD server daemon log                    |
-| `cmsd`                   | `/var/log/xrootd/server/cmsd.log`       | Cluster management log                      |
+| `xrootd`                 | `/var/log/xrootd/standalone/xrootd.log` | XRootD server daemon log                    |

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -351,19 +351,18 @@ root@host # systemctl start xrootd@standalone
 The services are:
 
 
-| Service                            | Service name                 |
-|:-----------------------------------|:-----------------------------|
-| XRootD (standalone config)         | `xrootd@standalone`          |
-| XRootD (clustered config)          | `xrootd@clustered`           |
-| XRootD (multiuser)                 | `xrootd-privileged@clustered`|
-| CMSD (clustered config)            | `cmsd@clustered`             |
-| CMSD (clustered config, multiuser) | `cmsd-privileged@clustered`  |
+| Service                    | EL 7 & 8 service name        |
+|:---------------------------|:-----------------------------|
+| XRootD (standalone config) | `xrootd@standalone`          |
+| XRootD (clustered config)  | `xrootd@clustered`           |
+| XRootD (multiuser)         | `xrootd-privileged@clustered`|
+| CMSD (clustered config)    | `cmsd@clustered`             |
 
 
 As a reminder, here are common service commands (all run as `root`):
 
 
-| To ...                                      | Run the command...               |
+| To ...                                      | On EL 7 & 8, run the command...  |
 |:--------------------------------------------|:---------------------------------|
 | Start a service                             | `systemctl start SERVICE-NAME`   |
 | Stop a service                              | `systemctl stop SERVICE-NAME`    |
@@ -378,24 +377,21 @@ To get assistance. please use the [Help Procedure](../../common/help.md) page.
 Reference
 ---------
 
-### File locations (standalone setup)
-
-See [the file locations section of the Install XRootD Standalone doc](install-standalone.md#file-locations)
+### File locations
 
 
-### File locations (clustered setup)
 
 | Service/Process | Configuration File                 | Description                              |
 |:----------------|:-----------------------------------|:-----------------------------------------|
 | `xrootd`        | `/etc/xrootd/xrootd-clustered.cfg` | Main clustered mode XRootD configuration |
 |                 | `/etc/xrootd/auth_file`            | Authorized users file                    |
 
-| Service/Process          | Log File                                   | Description                                 |
-|:-------------------------|:-------------------------------------------|:--------------------------------------------|
-| `xrootd`                 | `/var/log/xrootd/clustered/xrootd.log`     | XRootD server daemon log                    |
-| `cmsd`                   | `/var/log/xrootd/clustered/cmsd.log`       | Cluster management log                      |
-| `cns`                    | `/var/log/xrootd/clustered/cns/xrootd.log` | Server inventory (composite name space) log |
-| `frm_xfrd`, `frm_purged` | `/var/log/xrootd/clustered/frmd.log`       | File Residency Manager log                  |
+| Service/Process          | Log File                         | Description                                 |
+|:-------------------------|:---------------------------------|:--------------------------------------------|
+| `xrootd`                 | `/var/log/xrootd/xrootd.log`     | XRootD server daemon log                    |
+| `cmsd`                   | `/var/log/xrootd/cmsd.log`       | Cluster management log                      |
+| `cns`                    | `/var/log/xrootd/cns/xrootd.log` | Server inventory (composite name space) log |
+| `frm_xfrd`, `frm_purged` | `/var/log/xrootd/frmd.log`       | File Residency Manager log                  |
 
 
 

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -351,18 +351,19 @@ root@host # systemctl start xrootd@standalone
 The services are:
 
 
-| Service                    | EL 7 & 8 service name        |
-|:---------------------------|:-----------------------------|
-| XRootD (standalone config) | `xrootd@standalone`          |
-| XRootD (clustered config)  | `xrootd@clustered`           |
-| XRootD (multiuser)         | `xrootd-privileged@clustered`|
-| CMSD (clustered config)    | `cmsd@clustered`             |
+| Service                            | Service name                 |
+|:-----------------------------------|:-----------------------------|
+| XRootD (standalone config)         | `xrootd@standalone`          |
+| XRootD (clustered config)          | `xrootd@clustered`           |
+| XRootD (multiuser)                 | `xrootd-privileged@clustered`|
+| CMSD (clustered config)            | `cmsd@clustered`             |
+| CMSD (clustered config, multiuser) | `cmsd-privileged@clustered`  |
 
 
 As a reminder, here are common service commands (all run as `root`):
 
 
-| To ...                                      | On EL 7 & 8, run the command...  |
+| To ...                                      | Run the command...               |
 |:--------------------------------------------|:---------------------------------|
 | Start a service                             | `systemctl start SERVICE-NAME`   |
 | Stop a service                              | `systemctl stop SERVICE-NAME`    |
@@ -377,21 +378,24 @@ To get assistance. please use the [Help Procedure](../../common/help.md) page.
 Reference
 ---------
 
-### File locations
+### File locations (standalone setup)
+
+See [the file locations section of the Install XRootD Standalone doc](install-standalone.md#file-locations)
 
 
+### File locations (clustered setup)
 
 | Service/Process | Configuration File                 | Description                              |
 |:----------------|:-----------------------------------|:-----------------------------------------|
 | `xrootd`        | `/etc/xrootd/xrootd-clustered.cfg` | Main clustered mode XRootD configuration |
 |                 | `/etc/xrootd/auth_file`            | Authorized users file                    |
 
-| Service/Process          | Log File                         | Description                                 |
-|:-------------------------|:---------------------------------|:--------------------------------------------|
-| `xrootd`                 | `/var/log/xrootd/xrootd.log`     | XRootD server daemon log                    |
-| `cmsd`                   | `/var/log/xrootd/cmsd.log`       | Cluster management log                      |
-| `cns`                    | `/var/log/xrootd/cns/xrootd.log` | Server inventory (composite name space) log |
-| `frm_xfrd`, `frm_purged` | `/var/log/xrootd/frmd.log`       | File Residency Manager log                  |
+| Service/Process          | Log File                                   | Description                                 |
+|:-------------------------|:-------------------------------------------|:--------------------------------------------|
+| `xrootd`                 | `/var/log/xrootd/clustered/xrootd.log`     | XRootD server daemon log                    |
+| `cmsd`                   | `/var/log/xrootd/clustered/cmsd.log`       | Cluster management log                      |
+| `cns`                    | `/var/log/xrootd/clustered/cns/xrootd.log` | Server inventory (composite name space) log |
+| `frm_xfrd`, `frm_purged` | `/var/log/xrootd/clustered/frmd.log`       | File Residency Manager log                  |
 
 
 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -109,9 +109,7 @@ set EnableVoms = 1
     so this step is not necessary there.
 
 !!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
-    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
-    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, or XRootD 5.5.0 or newer.
-    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
+    Using XRootD-Multiuser with a VOMS FQAN requires XRootD 5.5.0 or newer.
 
 !!! warning "Key length requirements"
     Servers on EL 8 or newer will reject proxies that are not at least 2048 bits long.
@@ -146,9 +144,7 @@ i.e. authorize access to clients presenting the above proxy with `u blin ...` in
 #### Mapping VOMS attributes ####
 
 !!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
-    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
-    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, or XRootD 5.5.0 or newer.
-    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
+    Using XRootD-Multiuser with a VOMS FQAN requires XRootD 5.5.0 or newer.
 
 In OSG 3.6, if the XRootD-VOMS plugin is enabled,
 an incoming VOMS proxy will authenticate the first VOMS FQAN and map it to an organization name (`o`),

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -20,8 +20,7 @@ In the case of X.509 and VOMS proxies, after the incoming credential has been ma
 Authorizing Bearer Tokens
 -------------------------
 
-The [OSG 3.6](../../release/release_series.md#series-overviews) configurations of XRootD support authorization of bearer
-tokens such as macaroons, SciTokens, or WLCG tokens.
+XRootD supports authorization of bearer tokens such as macaroons, SciTokens, or WLCG tokens.
 Encoded in the bearer tokens themselves are information about the files that they should have read/write access to and
 in the case of SciTokens and WLCG tokens, you may configure XRootD to further restrict access.
 
@@ -122,7 +121,7 @@ set EnableVoms = 1
     If you have mapped the subject Distinguished Name (DN) of an incoming proxy with VOMS attributes,
     XRootD will map it to a username.
 
-In OSG 3.6, X.509 proxies are mapped using the built-in XRootD GSI plug-in.
+X.509 proxies are mapped using the built-in XRootD GSI plug-in.
 To map an incoming proxy's subject DN to an [XRootD username](#authorization-database),
 add lines of the following format to `/etc/grid-security/grid-mapfile`:
 
@@ -146,7 +145,7 @@ i.e. authorize access to clients presenting the above proxy with `u blin ...` in
 !!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
     Using XRootD-Multiuser with a VOMS FQAN requires XRootD 5.5.0 or newer.
 
-In OSG 3.6, if the XRootD-VOMS plugin is enabled,
+If the XRootD-VOMS plugin is enabled,
 an incoming VOMS proxy will authenticate the first VOMS FQAN and map it to an organization name (`o`),
 groupname (`g`), and role name (`r`) in the [authorization database](#authorization-database).
 For example, a proxy from the OSPool whose first VOMS FQAN is `/osg/Role=NULL/Capability=NULL` will be authenticated to
@@ -292,8 +291,7 @@ Verifying XRootD Authorization
 
 ### Bearer tokens ###
 
-To test read access using macaroon, SciTokens, and WLCG token authorization with an OSG 3.6 installation,
-run the following command:
+To test read access using macaroon, SciTokens, and WLCG token authorization, run the following command:
 
 ```console
 user@host $ curl -v \

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -350,6 +350,11 @@ pair, `xrootd-client`, and `voms-clients-cpp` installed:
     If your transfer does not succeed, re-run `xrdcp`  with `--debug 2` for more information.
 
 
+Updating to OSG 23
+------------------
+
+There are no manual steps necessary for authentication to work when upgrading from OSG 3.6 to OSG 23.
+If you are upgrading from an earlier version, see the [updating to OSG 3.6](#updating-to-osg-3-6) section below.
 
 Updating to OSG 3.6
 --------------------

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -354,7 +354,7 @@ Updating to OSG 23
 ------------------
 
 There are no manual steps necessary for authentication to work when upgrading from OSG 3.6 to OSG 23.
-If you are upgrading from an earlier version, see the [updating to OSG 3.6](#updating-to-osg-3-6) section below.
+If you are upgrading from an earlier release series, see the [updating to OSG 3.6](#updating-to-osg-3-6) section below.
 
 Updating to OSG 3.6
 --------------------


### PR DESCRIPTION
This updates the XRootD Standalone doc for OSG 23, and also some related docs (XRootD Storage Element, XRootD Authorization) since the changes were similar.