### PR TITLE
Update Let's Encrypt docs with info about Pelican/OSDF

### DIFF
--- a/docs/security/host-certs/lets-encrypt.md
+++ b/docs/security/host-certs/lets-encrypt.md
@@ -36,7 +36,7 @@ Installation and Obtaining the Initial Certificate
 
         If using host certificates for Pelican/OSDF:
         :::console
-        root@host # ln -sf /etc/letsencrypt/live/*/cert.pem /etc/pki/tls/certs/pelican.crt
+        root@host # ln -sf /etc/letsencrypt/live/*/fullchain.pem /etc/pki/tls/certs/pelican.crt
         root@host # ln -sf /etc/letsencrypt/live/*/privkey.pem /etc/pki/tls/private/pelican.key
         root@host # chmod 0600 /etc/letsencrypt/archive/*/privkey*.pem
 
@@ -45,6 +45,10 @@ Installation and Obtaining the Initial Certificate
         root@host # ln -sf /etc/letsencrypt/live/*/cert.pem /etc/grid-security/hostcert.pem
         root@host # ln -sf /etc/letsencrypt/live/*/privkey.pem /etc/grid-security/hostkey.pem
         root@host # chmod 0600 /etc/letsencrypt/archive/*/privkey*.pem
+
+
+    Note that Pelican requires the full certificate chain, not just the certificate,
+    so the pelican.crt symlink needs to point to fullchain.pem, not cert.pem.
 
 1. Restart services running on port 80 if there were any.
 

--- a/docs/security/host-certs/lets-encrypt.md
+++ b/docs/security/host-certs/lets-encrypt.md
@@ -34,6 +34,13 @@ Installation and Obtaining the Initial Certificate
 
 1. Set up hostcert/hostkey links:
 
+        If using host certificates for Pelican/OSDF:
+        :::console
+        root@host # ln -sf /etc/letsencrypt/live/*/cert.pem /etc/pki/tls/certs/pelican.crt
+        root@host # ln -sf /etc/letsencrypt/live/*/privkey.pem /etc/pki/tls/private/pelican.key
+        root@host # chmod 0600 /etc/letsencrypt/archive/*/privkey*.pem
+
+        If using host certificates for other software:
         :::console
         root@host # ln -sf /etc/letsencrypt/live/*/cert.pem /etc/grid-security/hostcert.pem
         root@host # ln -sf /etc/letsencrypt/live/*/privkey.pem /etc/grid-security/hostkey.pem


### PR DESCRIPTION
Pelican doesn't use the usual /etc/grid-security/... paths, and needs the full chain, not just the cert.