### PR TITLE
Do not require osg-testing or osg-upcoming-testing for osdf-cache

### DIFF
--- a/docs/data/osdf/install-cache-rpm.md
+++ b/docs/data/osdf/install-cache-rpm.md
@@ -65,12 +65,12 @@ Install it using one of the following commands:
 
 OSG 24:
 ```console
-root@host # yum install osdf-cache --enablerepo=osg-testing
+root@host # yum install osdf-cache
 ```
 
 OSG 23:
 ```console
-root@host # yum install --enablerepo=osg-upcoming-testing osdf-cache
+root@host # yum install --enablerepo=osg-upcoming osdf-cache
 ```
 
 !!! note "osdf-cache 7.11.1"


### PR DESCRIPTION
The required version of osdf-cache will be released tomorrow, so people won't have to get it out of testing anymore.