### PR TITLE
Add note about scratch-space permissions

### DIFF
--- a/docs/resource-sharing/os-backfill-containers.md
+++ b/docs/resource-sharing/os-backfill-containers.md
@@ -125,6 +125,10 @@ On EL hosts, the pilot container can also be managed via a systemctl service pro
 
             WORKER_TEMP_DIR=/scratch
 
+    !!! note "Scratch space ownership"
+        The EP is run under uid 1000.
+        Ensure this user has read, write, and execute access to the scratch space.
+
 1. Start the OSPool EP container service:
 
         :::console


### PR DESCRIPTION
I followed the instructions found at https://osg-htc.org/docs/resource-sharing/os-backfill-containers/ and found that I had to change the permissions on my scratch space directory. This updates the instructions to indicate this.

Two things to note:

1. This is the first time I have configured an EP, so please verify the suggestion this merge requests adds is correct.
2. I did not generate the HTML from the mkdocs sources. Feel free to edit my suggestion to suit the preferences of the document maintainer.