### PR TITLE
Revise instructions surrounding CVMFSEXEC_REPOS

### DIFF
--- a/docs/resource-sharing/os-backfill-containers.md
+++ b/docs/resource-sharing/os-backfill-containers.md
@@ -166,10 +166,10 @@ but the container will need fewer privileges.
 
 [cvmfsexec](https://github.com/CVMFS/cvmfsexec#readme) is a tool that can be used to mount CVMFS inside the container
 without requiring CVMFS on the host.
-To enable cvmfsexec, specify a space-separated list of repos in the `CVMFSEXEC_REPOS` environment variable.
+To enable cvmfsexec, specify a comma-separated list of repos in the `CVMFSEXEC_REPOS` environment variable.
 Adding the following line to `/etc/osg/ospool-ep.cfg` will enable the repos we recommend:
 ```
-CVMFSEXEC_REPOS=oasis.opensciencegrid.org singularity.opensciencegrid.org
+CVMFSEXEC_REPOS=oasis.opensciencegrid.org,singularity.opensciencegrid.org
 ```
 Note the absence of quotes around the definition. The startup scripts pass `/etc/osg/ospool-ep.cfg`
 into the container utility, and thus its definitions are not subject to shell syntax.

--- a/docs/resource-sharing/os-backfill-containers.md
+++ b/docs/resource-sharing/os-backfill-containers.md
@@ -167,10 +167,12 @@ but the container will need fewer privileges.
 [cvmfsexec](https://github.com/CVMFS/cvmfsexec#readme) is a tool that can be used to mount CVMFS inside the container
 without requiring CVMFS on the host.
 To enable cvmfsexec, specify a space-separated list of repos in the `CVMFSEXEC_REPOS` environment variable.
-At a minimum, we recommend enabling the following repos:
-
--   `oasis.opensciencegrid.org`
--   `singularity.opensciencegrid.org`
+Adding the following line to `/etc/osg/ospool-ep.cfg` will enable the repos we recommend:
+```
+CVMFSEXEC_REPOS=oasis.opensciencegrid.org singularity.opensciencegrid.org
+```
+Note the absence of quotes around the definition. The startup scripts pass `/etc/osg/ospool-ep.cfg`
+into the container utility, and thus its definitions are not subject to shell syntax.
 
 Additionally, you may set the following environment variables to further control the behavior of cvmfsexec:
 

--- a/docs/resource-sharing/os-backfill-containers.md
+++ b/docs/resource-sharing/os-backfill-containers.md
@@ -171,8 +171,9 @@ Adding the following line to `/etc/osg/ospool-ep.cfg` will enable the repos we r
 ```
 CVMFSEXEC_REPOS=oasis.opensciencegrid.org,singularity.opensciencegrid.org
 ```
-Note the absence of quotes around the definition. The startup scripts pass `/etc/osg/ospool-ep.cfg`
-into the container utility, and thus its definitions are not subject to shell syntax.
+
+!!! warning "Systemd environment files"
+    Systemd environment files do not honor shell syntax, i.e. variables are passed in directly as written
 
 Additionally, you may set the following environment variables to further control the behavior of cvmfsexec:
 


### PR DESCRIPTION
Since ospool-ep.cfg looks like shell syntax, someone might assume this is correct:

	CVMFSEXEC_REPOS="x y"

However, ospool-ep.cfg actually gets passed to the container utility using --env-file. Thus this is correct:

	CVMFSEXEC_REPOS=x y

Be more clear about this.