### PR TITLE
OSDF documentation: update the debugging instructions to use 'pelican object get' and tell the admin to set 'Logging.Level' instead of 'Debug'

### DIFF
--- a/docs/data/osdf/install-cache-container.md
+++ b/docs/data/osdf/install-cache-container.md
@@ -223,10 +223,14 @@ user@host $ docker logs osdf-cache
 
 To increase the debugging information in the cache, edit your cache configuration file and set:
 ```
-Debug: true
+Logging:
+  Level: debug
 ```
+Note that `debug` produces a lot of output and you should remove that setting or set it to `info`
+once the problem has been resolved.
 
-See [this page](../../common/help.md) for requesting assistance; please include the logs and the `pelican object get -d` output in your request.
+See [this page](../../common/help.md) for requesting assistance;
+please include the logs and the `pelican object get -d` output in your request.
 
 
 Joining the Cache to the Federation

--- a/docs/data/osdf/install-cache-rpm.md
+++ b/docs/data/osdf/install-cache-rpm.md
@@ -140,6 +140,15 @@ Do the following steps to verify that the cache is functional:
 
     If the download fails, rerun the above `pelican object get` command with the `-d` flag added;
     additional debugging information is located in `/var/log/pelican/osdf-cache.log`.
+
+    To increase the debugging information in the log file, edit your cache configuration file and set:
+    ```
+    Logging:
+      Level: debug
+    ```
+    Note that `debug` produces a lot of output and you should remove that setting or set it to `info`
+    once the problem has been resolved.
+
     See [this page](../../common/help.md) for requesting assistance; please include the log file
     and the `pelican object get -d` output in your request.
 

--- a/docs/data/osdf/install-origin-container.md
+++ b/docs/data/osdf/install-origin-container.md
@@ -230,18 +230,21 @@ user@host$ pelican object get -c ORIGIN_HOSTNAME:8443 'osdf:///<TEST_PATH>' -o /
 
 Verify the contents of `/tmp/testfile` match the test file or object your origin was serving.
 
-If you get errors, add the `--debug` flag to the `pelican object get` invocation.
+If the download fails, rerun the above `pelican object get` command with the `-d` flag added;
 
 Debugging information will be in your container logs e.g., `docker logs osdf-origin`.
 To increase the debugging information in the origin, edit your origin configuration file and set:
 ```
-Debug: true
 Logging:
+  Level: debug
   Origin:
     SciTokens: trace
 ```
+Note that `debug` produces a lot of output and you should remove that line or set it to `info`
+once the problem has been resolved.
 
-See [this page](../../common/help.md) for requesting assistance; please include the logs in your request.
+See [this page](../../common/help.md) for requesting assistance;
+please include the logs and `pelican object get --debug` output in your request.
 
 
 Joining the Origin to the Federation
@@ -277,11 +280,14 @@ docker logs osdf-origin
 ```
 To increase the debugging information in the origin, edit your origin configuration file and set:
 ```
-Debug: true
 Logging:
+  Level: debug
   Origin:
     SciTokens: trace
 ```
+Note that `debug` produces a lot of output and you should remove that line or set it to `info`
+once the problem has been resolved.
+
 See [this page](../../common/help.md) for requesting assistance; please include the logs in your request.
 
 1.  Download a test file (POSIX) or object (S3) directly from your origin,

--- a/docs/data/osdf/install-origin-rpm.md
+++ b/docs/data/osdf/install-origin-rpm.md
@@ -194,13 +194,25 @@ Do the following steps to verify that the origin is functional:
     and TEST_PATH with the OSDF path to the test file or object
 
         :::console
-        user@host$ curl -L https://ORIGIN_HOSTNAME:8443/TEST_PATH -o /tmp/testfile
+        user@host$ pelican object get -c ORIGIN_HOSTNAME:8443 'osdf:///<TEST_PATH>' -o /tmp/testfile
+
+    (Note: this test will not work if DirectReads are not enabled.)
 
     Verify the contents of `/tmp/testfile` match the test file or object your origin was serving.
 
-    If the download fails, debugging information is located in `/var/log/pelican/osdf-origin.log`.
+    If the download fails, rerun the above `pelican object get` command with the `-d` flag added;
+    additional debugging information is located in `/var/log/pelican/osdf-origin.log`.
+
+    To increase the debugging information in the log file, edit your cache configuration file and set:
+    ```
+    Logging:
+      Level: debug
+    ```
+    Note that `debug` produces a lot of output and you should remove that setting or set it to `info`
+    once the problem has been resolved.
+    
     See [this page](../../common/help.md) for requesting assistance; please include the log file
-    in your request.
+    and the `pelican object get -d` output in your request.
 
 
 Joining the Origin to the Federation


### PR DESCRIPTION
This should make the instructions more consistent between services and install instructions.