### PR TITLE
Redirect old StashCache docs to OSDF container docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,11 @@ plugins:
       redirect_maps:
         site-responsibilities.md: site-maintenance.md
         data/stashcache/overview.md: data/osdf/overview.md
+        data/stashcache/run-stashcache-container.md: data/osdf/install-cache-container.md
+        data/stashcache/run-stash-origin-container.md: data/osdf/install-origin-container.md
+        # Let's encourage container-based installations for things like OA4MP
+        data/stashcache/install-cache.md: data/osdf/install-cache-container.md
+        data/stashcache/install-origin.md: data/osdf/install-origin-container.md
         submit/osg-flock.md: submit/install-ospool-ap.md
         other/configuration-with-osg-configure.md: 'https://github.com/opensciencegrid/osg-configure?tab=readme-ov-file#osg-configure'
 


### PR DESCRIPTION
I want to encourage container-based installs over RPM-based installs
for things like OA4MP, which is impossible to do in the RPM scenario.